### PR TITLE
add ability to set response headers distinct from request headers

### DIFF
--- a/header.go
+++ b/header.go
@@ -4,61 +4,55 @@ import (
 	"net/http"
 )
 
-// RequestHeader is a decorator that injects a header value into every request.
-type RequestHeader struct {
-	wrapped  http.RoundTripper
-	provider RequestHeaderProvider
+// Header is a decorator that injects a header value into every request.
+type Header struct {
+	wrapped          http.RoundTripper
+	requestProvider  HeaderProvider
+	responseProvider ResponseHeaderProvider
 }
 
-// RequestHeaderProvider is mapping function that generates the required header name
+// HeaderProvider is mapping function that generates the required header name
 // and value from an outgoing request.
-type RequestHeaderProvider func(*http.Request) (headerName string, headerValue string)
+type HeaderProvider func(*http.Request) (headerName string, headerValue string)
 
 // RoundTrip annotates the outgoing request and calls the wrapped Client.
-func (c *RequestHeader) RoundTrip(r *http.Request) (*http.Response, error) {
-	var name, value = c.provider(r)
-	r.Header.Set(name, value)
-	return c.wrapped.RoundTrip(r)
+func (c *Header) RoundTrip(r *http.Request) (*http.Response, error) {
+	if c.requestProvider != nil {
+		var name, value = c.requestProvider(r)
+		r.Header.Set(name, value)
+	}
+	resp, err := c.wrapped.RoundTrip(r)
+	if err != nil {
+		return nil, err
+	}
+	if c.responseProvider != nil {
+		var name, value = c.responseProvider(resp)
+		resp.Header.Set(name, value)
+	}
+	return resp, nil
 }
 
-// NewRequestHeader wraps a transport in order to include custom headers.
-func NewRequestHeader(provider RequestHeaderProvider) func(http.RoundTripper) http.RoundTripper {
+// NewHeader wraps a transport in order to include custom request headers.
+func NewHeader(requestProvider HeaderProvider) func(http.RoundTripper) http.RoundTripper {
 	return func(c http.RoundTripper) http.RoundTripper {
-		return &RequestHeader{
-			wrapped:  c,
-			provider: provider,
+		return &Header{
+			wrapped:         c,
+			requestProvider: requestProvider,
 		}
 	}
-}
-
-// ResponseHeader is a decorator that injects a header value into every request.
-type ResponseHeader struct {
-	wrapped  http.RoundTripper
-	provider ResponseHeaderProvider
 }
 
 // ResponseHeaderProvider is mapping function that generates the required header name
 // and value to an outgoing response.
 type ResponseHeaderProvider func(*http.Response) (headerName string, headerValue string)
 
-// RoundTrip calls the wrapped Client and annotates the outgoing response
-func (c *ResponseHeader) RoundTrip(r *http.Request) (*http.Response, error) {
-
-	resp, err := c.wrapped.RoundTrip(r)
-	if err != nil {
-		return nil, err
-	}
-	var name, value = c.provider(resp)
-	resp.Header.Set(name, value)
-	return resp, nil
-}
-
-// NewResponseHeader wraps a transport in order to include custom headers.
-func NewResponseHeader(provider ResponseHeaderProvider) func(http.RoundTripper) http.RoundTripper {
+// NewHeaders wraps a transport in order to include custom request and response headers.
+func NewHeaders(requestProvider HeaderProvider, responseProvider ResponseHeaderProvider) func(http.RoundTripper) http.RoundTripper {
 	return func(c http.RoundTripper) http.RoundTripper {
-		return &ResponseHeader{
-			wrapped:  c,
-			provider: provider,
+		return &Header{
+			wrapped:          c,
+			requestProvider:  requestProvider,
+			responseProvider: responseProvider,
 		}
 	}
 }

--- a/header_test.go
+++ b/header_test.go
@@ -24,7 +24,7 @@ func TestRequestHeaderAddsHeaders(t *testing.T) {
 	}
 
 	var fixture = &fixtureHeaderTransport{}
-	var client = NewRequestHeader(provider)(fixture)
+	var client = NewHeader(provider)(fixture)
 	var r, _ = http.NewRequest("GET", "/", nil)
 	_, _ = client.RoundTrip(r)
 	if fixture.Request.Header.Get("KEY") != value {
@@ -41,7 +41,7 @@ func TestResponseHeaderAddsHeaders(t *testing.T) {
 
 	resp := &http.Response{Header: http.Header{}}
 	var fixture = &fixtureHeaderTransport{Response: resp}
-	var client = NewResponseHeader(provider)(fixture)
+	var client = NewHeaders(nil, provider)(fixture)
 	var r, _ = http.NewRequest("GET", "/", nil)
 	modifiedResp, _ := client.RoundTrip(r)
 	if fixture.Request.Header.Get("KEY") == value {

--- a/header_test.go
+++ b/header_test.go
@@ -16,17 +16,38 @@ func (c *fixtureHeaderTransport) RoundTrip(r *http.Request) (*http.Response, err
 	return c.Response, c.Err
 }
 
-func TestHeaderAddsHeaders(t *testing.T) {
+func TestRequestHeaderAddsHeaders(t *testing.T) {
+	const value string = "VALUE"
 	t.Parallel()
 	var provider = func(*http.Request) (string, string) {
-		return "KEY", "VALUE"
+		return "KEY", value
 	}
 
 	var fixture = &fixtureHeaderTransport{}
-	var client = NewHeader(provider)(fixture)
+	var client = NewRequestHeader(provider)(fixture)
 	var r, _ = http.NewRequest("GET", "/", nil)
 	_, _ = client.RoundTrip(r)
-	if fixture.Request.Header.Get("KEY") != "VALUE" {
+	if fixture.Request.Header.Get("KEY") != value {
 		t.Fatal("Decorator did not add headers to the request.")
+	}
+}
+
+func TestResponseHeaderAddsHeaders(t *testing.T) {
+	const value string = "VALUE"
+	t.Parallel()
+	var provider = func(*http.Response) (string, string) {
+		return "KEY", value
+	}
+
+	resp := &http.Response{Header: http.Header{}}
+	var fixture = &fixtureHeaderTransport{Response: resp}
+	var client = NewResponseHeader(provider)(fixture)
+	var r, _ = http.NewRequest("GET", "/", nil)
+	modifiedResp, _ := client.RoundTrip(r)
+	if fixture.Request.Header.Get("KEY") == value {
+		t.Fatal("Decorator should not add headers to the request.")
+	}
+	if modifiedResp.Header.Get("KEY") != value {
+		t.Fatal("Decorator did not add headers to the response.")
 	}
 }


### PR DESCRIPTION
For context, this PR allows for the injection of response headers as well as request headers.  The code prior to this PR only allowed for injection of inbound (request) headers, like [x-forwarded-for](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) (which is useful when this lib is being used in a proxy, for example).  This PR allows for setting outbound (response) headers, like [cache-control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) (which is useful when this lib is being used in a _reverse_ proxy, for example).