### PR TITLE
Update default transport to use clone feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@
 <!-- TOC -->
 
 - [transport](#transport)
-    - [Usage](#usage)
-        - [Creating A Transport](#creating-a-transport)
-        - [Decorators](#decorators)
-            - [Retry](#retry)
-            - [Hedging](#hedging)
-            - [Headers](#headers)
-            - [Decorator Chains](#decorator-chains)
-        - [Transport Extensions](#transport-extensions)
-            - [Recycle Transport](#recycle-transport)
-            - [Rotating Transport](#rotating-transport)
-    - [Contributing](#contributing)
-        - [License](#license)
-        - [Contributing Agreement](#contributing-agreement)
+  - [Usage](#usage)
+    - [Creating A Transport](#creating-a-transport)
+    - [Decorators](#decorators)
+      - [Retry](#retry)
+      - [Hedging](#hedging)
+      - [Headers](#headers)
+      - [Decorator Chains](#decorator-chains)
+    - [Transport Extensions](#transport-extensions)
+      - [Recycle Transport](#recycle-transport)
+      - [Rotating Transport](#rotating-transport)
+  - [Contributing](#contributing)
+    - [License](#license)
+    - [Contributing Agreement](#contributing-agreement)
 
 <!-- /TOC -->
 
@@ -44,7 +44,6 @@ functional arguments to make it easier to configure. For example:
 ```golang
 var client = &http.Client{
   Transport: transport.New(
-    transport.OptionDefaultTransport,
     transport.OptionMaxResponseHeaderBytes(4096),
     transport.OptionDisableCompression(true),
   ),
@@ -56,7 +55,6 @@ is able to produce any number of transports with the same configuration:
 
 ```golang
 var factory = transport.NewFactory(
-  transport.OptionDefaultTransport,
   transport.OptionMaxResponseHeaderBytes(4096),
   transport.OptionDisableCompression(true),
 )
@@ -98,7 +96,6 @@ var retryDecorator = transport.NewRetrier(
   ),
 )
 var t = transport.New(
-  transport.OptionDefaultTransport,
   transport.OptionMaxResponseHeaderBytes(4096),
   transport.OptionDisableCompression(true),
 )
@@ -129,7 +126,6 @@ var hedgingDecorator = transport.NewHedger(
 	transport.NewFixedBackoffPolicy(50*time.Millisecond),
 )
 var t = transport.New(
-	transport.OptionDefaultTransport,
 	transport.OptionMaxResponseHeaderBytes(4096),
 	transport.OptionDisableCompression(true),
 )
@@ -159,7 +155,6 @@ var headerDecorator = transport.NewHeader(
   }
 )
 var t = transport.New(
-  transport.OptionDefaultTransport,
   transport.OptionMaxResponseHeaderBytes(4096),
   transport.OptionDisableCompression(true),
 )
@@ -199,7 +194,6 @@ var chain = transport.Chain{
   headerDecorator,
 }
 var t = transport.New(
-  transport.OptionDefaultTransport,
   transport.OptionMaxResponseHeaderBytes(4096),
   transport.OptionDisableCompression(true),
 )
@@ -262,7 +256,6 @@ var chain = transport.Chain{
   headerDecorator,
 }
 var factory = transport.NewFactory(
-  transport.OptionDefaultTransport,
   transport.OptionMaxResponseHeaderBytes(4096),
   transport.OptionDisableCompression(true),
 )
@@ -324,7 +317,6 @@ var chain = transport.Chain{
   headerDecorator,
 }
 var factory = transport.NewFactory(
-  transport.OptionDefaultTransport,
   transport.OptionMaxResponseHeaderBytes(4096),
   transport.OptionDisableCompression(true),
 )

--- a/transport.go
+++ b/transport.go
@@ -144,13 +144,27 @@ func OptionMaxResponseHeaderBytes(max int64) Option {
 }
 
 // OptionDefaultTransport configures a transport to match the http.DefaultTransport.
+//
+// Deprecated: The New() method uses a copy of the http.DefaultTransport as the
+// base transport on which options are applied. This option is redundant and
+// can be removed wherever it is used.
 func OptionDefaultTransport(t *http.Transport) *http.Transport {
-	return http.DefaultTransport.(*http.Transport).Clone()
+	t = OptionProxy(http.ProxyFromEnvironment)(t)
+	t = OptionDialContext((&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		DualStack: true,
+	}).DialContext)(t)
+	t = OptionMaxIdleConns(100)(t)
+	t = OptionIdleConnTimeout(90 * time.Second)(t)
+	t = OptionTLSHandshakeTimeout(10 * time.Second)(t)
+	t = OptionExpectContinueTimeout(time.Second)(t)
+	return t
 }
 
 // New applies the given options to a Transport and returns it.
 func New(opts ...Option) *http.Transport {
-	var t = &http.Transport{}
+	var t = http.DefaultTransport.(*http.Transport).Clone()
 	for _, opt := range opts {
 		t = opt(t)
 	}

--- a/transport.go
+++ b/transport.go
@@ -145,17 +145,7 @@ func OptionMaxResponseHeaderBytes(max int64) Option {
 
 // OptionDefaultTransport configures a transport to match the http.DefaultTransport.
 func OptionDefaultTransport(t *http.Transport) *http.Transport {
-	t = OptionProxy(http.ProxyFromEnvironment)(t)
-	t = OptionDialContext((&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-		DualStack: true,
-	}).DialContext)(t)
-	t = OptionMaxIdleConns(100)(t)
-	t = OptionIdleConnTimeout(90 * time.Second)(t)
-	t = OptionTLSHandshakeTimeout(10 * time.Second)(t)
-	t = OptionExpectContinueTimeout(time.Second)(t)
-	return t
+	return http.DefaultTransport.(*http.Transport).Clone()
 }
 
 // New applies the given options to a Transport and returns it.

--- a/transport_test.go
+++ b/transport_test.go
@@ -16,6 +16,10 @@ type optionTestCase struct {
 	Verifier func(*http.Transport) error
 }
 
+func optionNOP(t *http.Transport) *http.Transport {
+	return t
+}
+
 func TestTransportOptions(t *testing.T) { //nolint:gocyclo
 	var testErr = errors.New("")
 	var proxyFunc = func(*http.Request) (*url.URL, error) {
@@ -139,6 +143,49 @@ func TestTransportOptions(t *testing.T) { //nolint:gocyclo
 			return nil
 		}},
 		{Name: "OptionDefaultTransport", Option: OptionDefaultTransport, Verifier: func(tr *http.Transport) error { //nolint:gocyclo
+			dtr := http.DefaultTransport.(*http.Transport)
+			if tr.TLSHandshakeTimeout != dtr.TLSHandshakeTimeout {
+				return errors.New("default transport value TLSHandshakeTimeout not copied")
+			}
+			if tr.DisableKeepAlives != dtr.DisableKeepAlives {
+				return errors.New("default transport value DisableKeepAlives not copied")
+			}
+			if tr.DisableCompression != dtr.DisableCompression {
+				return errors.New("default transport value DisableCompression not copied")
+			}
+			if tr.MaxIdleConns != dtr.MaxIdleConns {
+				return errors.New("default transport value MaxIdleConns not copied")
+			}
+			if tr.MaxIdleConnsPerHost != dtr.MaxIdleConnsPerHost {
+				return errors.New("default transport value MaxIdleConnsPerHost not copied")
+			}
+			if tr.MaxConnsPerHost != dtr.MaxConnsPerHost {
+				return errors.New("default transport value MaxConnsPerHost not copied")
+			}
+			if tr.IdleConnTimeout != dtr.IdleConnTimeout {
+				return errors.New("default transport value IdleConnTimeout not copied")
+			}
+			if tr.ResponseHeaderTimeout != dtr.ResponseHeaderTimeout {
+				return errors.New("default transport value ResponseHeaderTimeout not copied")
+			}
+			if tr.ExpectContinueTimeout != dtr.ExpectContinueTimeout {
+				return errors.New("default transport value ExpectContinueTimeout not copied")
+			}
+			if tr.MaxResponseHeaderBytes != dtr.MaxResponseHeaderBytes {
+				return errors.New("default transport value MaxResponseHeaderBytes not copied")
+			}
+			if tr.ForceAttemptHTTP2 != dtr.ForceAttemptHTTP2 {
+				return errors.New("default transport value ForceAttemptHTTP2 not copied")
+			}
+			if tr.WriteBufferSize != dtr.WriteBufferSize {
+				return errors.New("default transport value WriteBufferSize not copied")
+			}
+			if tr.ReadBufferSize != dtr.ReadBufferSize {
+				return errors.New("default transport value ReadBufferSize not copied")
+			}
+			return nil
+		}},
+		{Name: "No Options Enabled", Option: optionNOP, Verifier: func(tr *http.Transport) error { //nolint:gocyclo
 			dtr := http.DefaultTransport.(*http.Transport)
 			if tr.TLSHandshakeTimeout != dtr.TLSHandshakeTimeout {
 				return errors.New("default transport value TLSHandshakeTimeout not copied")

--- a/transport_test.go
+++ b/transport_test.go
@@ -16,8 +16,54 @@ type optionTestCase struct {
 	Verifier func(*http.Transport) error
 }
 
+// optionNOP is used to test a case where no options are enabled.
 func optionNOP(t *http.Transport) *http.Transport {
 	return t
+}
+
+// verifyDefault compares a transport against the http.DefaultTransport.
+func verifyDefault(tr *http.Transport) error { //nolint:gocyclo
+	dtr := http.DefaultTransport.(*http.Transport)
+	if tr.TLSHandshakeTimeout != dtr.TLSHandshakeTimeout {
+		return errors.New("default transport value TLSHandshakeTimeout not copied")
+	}
+	if tr.DisableKeepAlives != dtr.DisableKeepAlives {
+		return errors.New("default transport value DisableKeepAlives not copied")
+	}
+	if tr.DisableCompression != dtr.DisableCompression {
+		return errors.New("default transport value DisableCompression not copied")
+	}
+	if tr.MaxIdleConns != dtr.MaxIdleConns {
+		return errors.New("default transport value MaxIdleConns not copied")
+	}
+	if tr.MaxIdleConnsPerHost != dtr.MaxIdleConnsPerHost {
+		return errors.New("default transport value MaxIdleConnsPerHost not copied")
+	}
+	if tr.MaxConnsPerHost != dtr.MaxConnsPerHost {
+		return errors.New("default transport value MaxConnsPerHost not copied")
+	}
+	if tr.IdleConnTimeout != dtr.IdleConnTimeout {
+		return errors.New("default transport value IdleConnTimeout not copied")
+	}
+	if tr.ResponseHeaderTimeout != dtr.ResponseHeaderTimeout {
+		return errors.New("default transport value ResponseHeaderTimeout not copied")
+	}
+	if tr.ExpectContinueTimeout != dtr.ExpectContinueTimeout {
+		return errors.New("default transport value ExpectContinueTimeout not copied")
+	}
+	if tr.MaxResponseHeaderBytes != dtr.MaxResponseHeaderBytes {
+		return errors.New("default transport value MaxResponseHeaderBytes not copied")
+	}
+	if tr.ForceAttemptHTTP2 != dtr.ForceAttemptHTTP2 {
+		return errors.New("default transport value ForceAttemptHTTP2 not copied")
+	}
+	if tr.WriteBufferSize != dtr.WriteBufferSize {
+		return errors.New("default transport value WriteBufferSize not copied")
+	}
+	if tr.ReadBufferSize != dtr.ReadBufferSize {
+		return errors.New("default transport value ReadBufferSize not copied")
+	}
+	return nil
 }
 
 func TestTransportOptions(t *testing.T) { //nolint:gocyclo
@@ -142,92 +188,8 @@ func TestTransportOptions(t *testing.T) { //nolint:gocyclo
 			}
 			return nil
 		}},
-		{Name: "OptionDefaultTransport", Option: OptionDefaultTransport, Verifier: func(tr *http.Transport) error { //nolint:gocyclo
-			dtr := http.DefaultTransport.(*http.Transport)
-			if tr.TLSHandshakeTimeout != dtr.TLSHandshakeTimeout {
-				return errors.New("default transport value TLSHandshakeTimeout not copied")
-			}
-			if tr.DisableKeepAlives != dtr.DisableKeepAlives {
-				return errors.New("default transport value DisableKeepAlives not copied")
-			}
-			if tr.DisableCompression != dtr.DisableCompression {
-				return errors.New("default transport value DisableCompression not copied")
-			}
-			if tr.MaxIdleConns != dtr.MaxIdleConns {
-				return errors.New("default transport value MaxIdleConns not copied")
-			}
-			if tr.MaxIdleConnsPerHost != dtr.MaxIdleConnsPerHost {
-				return errors.New("default transport value MaxIdleConnsPerHost not copied")
-			}
-			if tr.MaxConnsPerHost != dtr.MaxConnsPerHost {
-				return errors.New("default transport value MaxConnsPerHost not copied")
-			}
-			if tr.IdleConnTimeout != dtr.IdleConnTimeout {
-				return errors.New("default transport value IdleConnTimeout not copied")
-			}
-			if tr.ResponseHeaderTimeout != dtr.ResponseHeaderTimeout {
-				return errors.New("default transport value ResponseHeaderTimeout not copied")
-			}
-			if tr.ExpectContinueTimeout != dtr.ExpectContinueTimeout {
-				return errors.New("default transport value ExpectContinueTimeout not copied")
-			}
-			if tr.MaxResponseHeaderBytes != dtr.MaxResponseHeaderBytes {
-				return errors.New("default transport value MaxResponseHeaderBytes not copied")
-			}
-			if tr.ForceAttemptHTTP2 != dtr.ForceAttemptHTTP2 {
-				return errors.New("default transport value ForceAttemptHTTP2 not copied")
-			}
-			if tr.WriteBufferSize != dtr.WriteBufferSize {
-				return errors.New("default transport value WriteBufferSize not copied")
-			}
-			if tr.ReadBufferSize != dtr.ReadBufferSize {
-				return errors.New("default transport value ReadBufferSize not copied")
-			}
-			return nil
-		}},
-		{Name: "No Options Enabled", Option: optionNOP, Verifier: func(tr *http.Transport) error { //nolint:gocyclo
-			dtr := http.DefaultTransport.(*http.Transport)
-			if tr.TLSHandshakeTimeout != dtr.TLSHandshakeTimeout {
-				return errors.New("default transport value TLSHandshakeTimeout not copied")
-			}
-			if tr.DisableKeepAlives != dtr.DisableKeepAlives {
-				return errors.New("default transport value DisableKeepAlives not copied")
-			}
-			if tr.DisableCompression != dtr.DisableCompression {
-				return errors.New("default transport value DisableCompression not copied")
-			}
-			if tr.MaxIdleConns != dtr.MaxIdleConns {
-				return errors.New("default transport value MaxIdleConns not copied")
-			}
-			if tr.MaxIdleConnsPerHost != dtr.MaxIdleConnsPerHost {
-				return errors.New("default transport value MaxIdleConnsPerHost not copied")
-			}
-			if tr.MaxConnsPerHost != dtr.MaxConnsPerHost {
-				return errors.New("default transport value MaxConnsPerHost not copied")
-			}
-			if tr.IdleConnTimeout != dtr.IdleConnTimeout {
-				return errors.New("default transport value IdleConnTimeout not copied")
-			}
-			if tr.ResponseHeaderTimeout != dtr.ResponseHeaderTimeout {
-				return errors.New("default transport value ResponseHeaderTimeout not copied")
-			}
-			if tr.ExpectContinueTimeout != dtr.ExpectContinueTimeout {
-				return errors.New("default transport value ExpectContinueTimeout not copied")
-			}
-			if tr.MaxResponseHeaderBytes != dtr.MaxResponseHeaderBytes {
-				return errors.New("default transport value MaxResponseHeaderBytes not copied")
-			}
-			if tr.ForceAttemptHTTP2 != dtr.ForceAttemptHTTP2 {
-				return errors.New("default transport value ForceAttemptHTTP2 not copied")
-			}
-			if tr.WriteBufferSize != dtr.WriteBufferSize {
-				return errors.New("default transport value WriteBufferSize not copied")
-			}
-			if tr.ReadBufferSize != dtr.ReadBufferSize {
-				return errors.New("default transport value ReadBufferSize not copied")
-			}
-			return nil
-		}},
+		{Name: "OptionDefaultTransport", Option: OptionDefaultTransport, Verifier: verifyDefault},
+		{Name: "No Options Enabled", Option: optionNOP, Verifier: verifyDefault},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(tb *testing.T) {

--- a/transport_test.go
+++ b/transport_test.go
@@ -16,7 +16,7 @@ type optionTestCase struct {
 	Verifier func(*http.Transport) error
 }
 
-func TestTransportOptions(t *testing.T) {
+func TestTransportOptions(t *testing.T) { //nolint:gocyclo
 	var testErr = errors.New("")
 	var proxyFunc = func(*http.Request) (*url.URL, error) {
 		return nil, testErr
@@ -135,6 +135,49 @@ func TestTransportOptions(t *testing.T) {
 		{Name: "OptionMaxResponseHeaderBytes", Option: OptionMaxResponseHeaderBytes(1), Verifier: func(tr *http.Transport) error {
 			if tr.MaxResponseHeaderBytes != 1 {
 				return errors.New("limit was not set by OptionMaxResponseHeaderBytes")
+			}
+			return nil
+		}},
+		{Name: "OptionDefaultTransport", Option: OptionDefaultTransport, Verifier: func(tr *http.Transport) error { //nolint:gocyclo
+			dtr := http.DefaultTransport.(*http.Transport)
+			if tr.TLSHandshakeTimeout != dtr.TLSHandshakeTimeout {
+				return errors.New("default transport value TLSHandshakeTimeout not copied")
+			}
+			if tr.DisableKeepAlives != dtr.DisableKeepAlives {
+				return errors.New("default transport value DisableKeepAlives not copied")
+			}
+			if tr.DisableCompression != dtr.DisableCompression {
+				return errors.New("default transport value DisableCompression not copied")
+			}
+			if tr.MaxIdleConns != dtr.MaxIdleConns {
+				return errors.New("default transport value MaxIdleConns not copied")
+			}
+			if tr.MaxIdleConnsPerHost != dtr.MaxIdleConnsPerHost {
+				return errors.New("default transport value MaxIdleConnsPerHost not copied")
+			}
+			if tr.MaxConnsPerHost != dtr.MaxConnsPerHost {
+				return errors.New("default transport value MaxConnsPerHost not copied")
+			}
+			if tr.IdleConnTimeout != dtr.IdleConnTimeout {
+				return errors.New("default transport value IdleConnTimeout not copied")
+			}
+			if tr.ResponseHeaderTimeout != dtr.ResponseHeaderTimeout {
+				return errors.New("default transport value ResponseHeaderTimeout not copied")
+			}
+			if tr.ExpectContinueTimeout != dtr.ExpectContinueTimeout {
+				return errors.New("default transport value ExpectContinueTimeout not copied")
+			}
+			if tr.MaxResponseHeaderBytes != dtr.MaxResponseHeaderBytes {
+				return errors.New("default transport value MaxResponseHeaderBytes not copied")
+			}
+			if tr.ForceAttemptHTTP2 != dtr.ForceAttemptHTTP2 {
+				return errors.New("default transport value ForceAttemptHTTP2 not copied")
+			}
+			if tr.WriteBufferSize != dtr.WriteBufferSize {
+				return errors.New("default transport value WriteBufferSize not copied")
+			}
+			if tr.ReadBufferSize != dtr.ReadBufferSize {
+				return errors.New("default transport value ReadBufferSize not copied")
 			}
 			return nil
 		}},


### PR DESCRIPTION
This helps ensure the OptionDefaultTransport is always up to date by
leveraging the built-in Clone() method of the *http.Transport.

The added test is a basic check to ensure that all the comparable values
match. Additional fields may appear over time but this _should_ be
enough to prove that the Clone() feature is working as expected.