### PR TITLE
make a RetryAfter middleware to honor a 429 Retry-After header value

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/asecurityteam/transport
 
 go 1.12
 
-require github.com/golang/mock v1.2.0
+require github.com/golang/mock v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,13 @@
 github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.4.3 h1:GV+pQPG/EUUbkh47niozDcADz6go/dUwhVzdUQHIVRw=
+github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
+rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/retryafter.go
+++ b/retryafter.go
@@ -1,0 +1,66 @@
+package transport
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// RetryAfter determines whether or not the transport will automatically retry
+// a request based on configured behaviors for 429 responses with Retry-After header.
+type RetryAfter struct {
+	wrapped http.RoundTripper
+}
+
+// RoundTrip executes a request and applies one or more retry policies.
+func (c *RetryAfter) RoundTrip(r *http.Request) (*http.Response, error) {
+	var copier, e = newRequestCopier(r)
+	var parentCtx = r.Context()
+	if e != nil {
+		return nil, e
+	}
+	var response *http.Response
+	var requestCtx, cancel = context.WithCancel(parentCtx)
+	var req = copier.Copy().WithContext(requestCtx)
+
+	retryAfter := 0
+	for {
+		select {
+		case <-parentCtx.Done():
+			cancel()
+			return nil, parentCtx.Err()
+		case <-time.After(time.Duration(retryAfter) * time.Millisecond):
+		}
+		cancel()
+		requestCtx, cancel = context.WithCancel(parentCtx) // nolint
+		response, e = c.wrapped.RoundTrip(req)
+		if e != nil {
+			break
+		}
+		if response.StatusCode != 429 {
+			break
+		} else {
+			retryAfterString := response.Header.Get("Retry-After")
+			if retryAfterString == "" {
+				break
+			}
+			var err error
+			if retryAfter, err = strconv.Atoi(retryAfterString); err != nil {
+				break
+			}
+		}
+	}
+	if e != nil {
+		cancel()
+	}
+	return response, e // nolint
+}
+
+// NewRetryAfter configures a RoundTripper decorator to perform some number of
+// retries.
+func NewRetryAfter() func(http.RoundTripper) http.RoundTripper {
+	return func(wrapped http.RoundTripper) http.RoundTripper {
+		return &RetryAfter{wrapped: wrapped}
+	}
+}

--- a/retryafter_test.go
+++ b/retryafter_test.go
@@ -1,0 +1,199 @@
+package transport
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	gomock "github.com/golang/mock/gomock"
+)
+
+func TestRetryAfterNot429(t *testing.T) {
+	t.Parallel()
+
+	var ctrl = gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var wrapped = NewMockRoundTripper(ctrl)
+	var rt = NewRetryAfter()(wrapped)
+
+	rtFunc := func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       http.NoBody,
+		}, nil
+	}
+
+	wrapped.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(rtFunc).Times(1)
+
+	var req, _ = http.NewRequest(http.MethodGet, "/", nil)
+	var resp, e = rt.RoundTrip(req)
+	if e != nil {
+		t.Fatal(e.Error())
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 but got %d", resp.StatusCode)
+	}
+}
+
+func TestRetryAfter429NoRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	var ctrl = gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var wrapped = NewMockRoundTripper(ctrl)
+	var rt = NewRetryAfter()(wrapped)
+
+	rtFunc := func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 429,
+			Body:       http.NoBody,
+		}, nil
+	}
+
+	wrapped.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(rtFunc).Times(1)
+
+	var req, _ = http.NewRequest(http.MethodGet, "/", nil)
+	var resp, e = rt.RoundTrip(req)
+	if e != nil {
+		t.Fatal(e.Error())
+	}
+	if resp.StatusCode != 429 {
+		t.Fatalf("expected 429 but got %d", resp.StatusCode)
+	}
+}
+
+func TestRetryAfter429BadRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	var ctrl = gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var wrapped = NewMockRoundTripper(ctrl)
+	var rt = NewRetryAfter()(wrapped)
+
+	rtFunc := func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 429,
+			Body:       http.NoBody,
+			Header: map[string][]string{
+				"Retry-After": []string{"bogus header value"},
+			},
+		}, nil
+	}
+
+	wrapped.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(rtFunc).Times(1)
+
+	var req, _ = http.NewRequest(http.MethodGet, "/", nil)
+	var resp, e = rt.RoundTrip(req)
+	if e != nil {
+		t.Fatal(e.Error())
+	}
+	if resp.StatusCode != 429 {
+		t.Fatalf("expected 429 but got %d", resp.StatusCode)
+	}
+}
+
+func TestRetryAfter429WithRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	var ctrl = gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var wrapped = NewMockRoundTripper(ctrl)
+	var rt = NewRetryAfter()(wrapped)
+
+	rtFunc1 := func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 429,
+			Body:       http.NoBody,
+			Header: map[string][]string{
+				"Retry-After": []string{"1000"},
+			},
+		}, nil
+	}
+
+	rtFunc2 := func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       http.NoBody,
+		}, nil
+	}
+
+	wrapped.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(rtFunc1).Times(1)
+	wrapped.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(rtFunc2).Times(1)
+
+	var req, _ = http.NewRequest(http.MethodGet, "/", nil)
+	var resp, e = rt.RoundTrip(req)
+	if e != nil {
+		t.Fatal(e.Error())
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200 but got %d", resp.StatusCode)
+	}
+}
+
+func TestRetryAfter429WithDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+
+	var ctrl = gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var wrapped = NewMockRoundTripper(ctrl)
+	var rt = NewRetryAfter()(wrapped)
+
+	var ctx, cancel = context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+
+	rtFunc1 := func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 429,
+			Body:       http.NoBody,
+			Header: map[string][]string{
+				"Retry-After": []string{"1000"},
+			},
+		}, nil
+	}
+
+	rtFunc2 := func(r *http.Request) (*http.Response, error) {
+		cancel()
+		return nil, context.DeadlineExceeded
+	}
+
+	wrapped.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(rtFunc1).Times(1)
+	wrapped.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(rtFunc2).Times(1)
+
+	var req, _ = http.NewRequest(http.MethodGet, "/", nil)
+	var _, e = rt.RoundTrip(req.WithContext(ctx))
+	if e == nil {
+		t.Fatal("expected an error but got nil")
+	}
+}
+
+func TestRetryContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	var ctrl = gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var wrapped = NewMockRoundTripper(ctrl)
+	var rt = NewRetryAfter()(wrapped)
+
+	var ctx, cancel = context.WithTimeout(context.Background(), time.Hour)
+	defer cancel()
+
+	rtFunc := func(r *http.Request) (*http.Response, error) {
+		cancel()
+		return nil, context.DeadlineExceeded
+	}
+
+	wrapped.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(rtFunc).Times(1)
+
+	var req, _ = http.NewRequest(http.MethodGet, "/", nil)
+	var _, e = rt.RoundTrip(req.WithContext(ctx))
+	if e == nil {
+		t.Fatal("expected an error but got nil")
+	}
+}


### PR DESCRIPTION
This new middleware piece will honor a 429 "Retry-After" header value if/when it's present.  This PR lacks the following, which you may commence to request if you deem it necessary:

- a configurable ceiling on the Retry-After value (if, for example, the Retry-After is 30 _minutes_, we may want a configuration that says `if Retry-After > 10 seconds, pass through`.  Could call it `RetryAfterValueHonorLimit` or something
