### PR TITLE
retryafter component is canceling too aggressively where it shouldn't

### DIFF
--- a/retryafter.go
+++ b/retryafter.go
@@ -33,7 +33,6 @@ func (c *RetryAfter) RoundTrip(r *http.Request) (*http.Response, error) {
 				return nil, parentCtx.Err()
 			case <-time.After(time.Duration(retryAfter) * time.Millisecond):
 			}
-			cancel()
 			requestCtx, cancel = context.WithCancel(parentCtx) // nolint
 			req = copier.Copy().WithContext(requestCtx)
 		}

--- a/retryafter_test.go
+++ b/retryafter_test.go
@@ -110,7 +110,7 @@ func TestRetryAfter429WithRetryAfter(t *testing.T) {
 			StatusCode: 429,
 			Body:       http.NoBody,
 			Header: map[string][]string{
-				"Retry-After": []string{"1000"},
+				"Retry-After": []string{"10"},
 			},
 		}, nil
 	}
@@ -152,7 +152,7 @@ func TestRetryAfter429WithDeadlineExceeded(t *testing.T) {
 			StatusCode: 429,
 			Body:       http.NoBody,
 			Header: map[string][]string{
-				"Retry-After": []string{"1000"},
+				"Retry-After": []string{"10"},
 			},
 		}, nil
 	}


### PR DESCRIPTION
The result is that if a 429 with a Retry-After header with a parseable value is ever returned, and the component is used in the context of transportd where other components are decorated/wrapped around it, the context gets canceled and communication with the server is cut.