### PR TITLE
make RetryAfter RoundTripper decorator configurable with a backoff po…

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,7 @@ github.com/golang/mock v1.4.3 h1:GV+pQPG/EUUbkh47niozDcADz6go/dUwhVzdUQHIVRw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
+github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=
 github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNEe7i7qA=
@@ -37,6 +38,7 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/retry.go
+++ b/retry.go
@@ -183,6 +183,28 @@ func (b *FixedBackoffer) Backoff(*http.Request, *http.Response, error) time.Dura
 	return b.wait
 }
 
+// ExponentialBackoffer signals the client to wait for an initial amount of time,
+// doubling every retry
+type ExponentialBackoffer struct {
+	wait time.Duration
+}
+
+// NewExponentialBackoffPolicy generates a BackoffPolicy that returns double the value
+// returned in the previous call, using the wait parameter as the initial backoff value
+func NewExponentialBackoffPolicy(wait time.Duration) BackoffPolicy {
+	var backoffer = &ExponentialBackoffer{wait: wait}
+	return func() Backoffer {
+		return backoffer
+	}
+}
+
+// Backoff for an initial amount of time, doubling each retry
+func (b *ExponentialBackoffer) Backoff(*http.Request, *http.Response, error) time.Duration {
+	current := b.wait
+	b.wait = b.wait * 2
+	return current
+}
+
 // PercentJitteredBackoffer adjusts the backoff time by a random amount within
 // N percent of the duration to help with thundering herds.
 type PercentJitteredBackoffer struct {

--- a/retryafter.go
+++ b/retryafter.go
@@ -10,7 +10,8 @@ import (
 // RetryAfter determines whether or not the transport will automatically retry
 // a request based on configured behaviors for 429 responses with Retry-After header.
 type RetryAfter struct {
-	wrapped http.RoundTripper
+	wrapped       http.RoundTripper
+	backoffPolicy BackoffPolicy
 }
 
 // RoundTrip executes a request and applies one or more retry policies.
@@ -24,14 +25,15 @@ func (c *RetryAfter) RoundTrip(r *http.Request) (*http.Response, error) {
 	var requestCtx, cancel = context.WithCancel(parentCtx)
 	var req = copier.Copy().WithContext(requestCtx)
 
-	retryAfter := 0
+	var backoffer = c.backoffPolicy()
+	var retryAfter time.Duration
 	for {
 		if retryAfter > 0 {
 			select {
 			case <-parentCtx.Done():
 				cancel()
 				return nil, parentCtx.Err()
-			case <-time.After(time.Duration(retryAfter) * time.Millisecond):
+			case <-time.After(retryAfter):
 			}
 			cancel()
 			requestCtx, cancel = context.WithCancel(parentCtx) // nolint
@@ -46,11 +48,14 @@ func (c *RetryAfter) RoundTrip(r *http.Request) (*http.Response, error) {
 		} else {
 			retryAfterString := response.Header.Get("Retry-After")
 			if retryAfterString == "" {
-				break
-			}
-			var err error
-			if retryAfter, err = strconv.Atoi(retryAfterString); err != nil {
-				break
+				retryAfter = backoffer.Backoff(r, response, e)
+			} else {
+				var retryAfterInt int
+				var err error
+				if retryAfterInt, err = strconv.Atoi(retryAfterString); err != nil {
+					break
+				}
+				retryAfter = time.Duration(retryAfterInt) * time.Millisecond
 			}
 		}
 	}
@@ -60,10 +65,10 @@ func (c *RetryAfter) RoundTrip(r *http.Request) (*http.Response, error) {
 	return response, e // nolint
 }
 
-// NewRetryAfter configures a RoundTripper decorator to perform some number of
-// retries.
-func NewRetryAfter() func(http.RoundTripper) http.RoundTripper {
+// NewRetryAfter configures a RoundTripper decorator to honor a status code 429 response,
+// using the Retry-After header directive when present, or the backoffPolicy if not present.
+func NewRetryAfter(backoffPolicy BackoffPolicy) func(http.RoundTripper) http.RoundTripper {
 	return func(wrapped http.RoundTripper) http.RoundTripper {
-		return &RetryAfter{wrapped: wrapped}
+		return &RetryAfter{wrapped: wrapped, backoffPolicy: backoffPolicy}
 	}
 }

--- a/retryafter.go
+++ b/retryafter.go
@@ -67,8 +67,8 @@ func (c *RetryAfter) RoundTrip(r *http.Request) (*http.Response, error) {
 
 // NewRetryAfter configures a RoundTripper decorator to honor a status code 429 response,
 // using the Retry-After header directive when present, or the backoffPolicy if not present.
-func NewRetryAfter(backoffPolicy BackoffPolicy) func(http.RoundTripper) http.RoundTripper {
+func NewRetryAfter() func(http.RoundTripper) http.RoundTripper {
 	return func(wrapped http.RoundTripper) http.RoundTripper {
-		return &RetryAfter{wrapped: wrapped, backoffPolicy: backoffPolicy}
+		return &RetryAfter{wrapped: wrapped, backoffPolicy: NewExponentialBackoffPolicy(20 * time.Millisecond)}
 	}
 }

--- a/retryafter_test.go
+++ b/retryafter_test.go
@@ -16,7 +16,7 @@ func TestRetryAfterNot429(t *testing.T) {
 	defer ctrl.Finish()
 
 	var wrapped = NewMockRoundTripper(ctrl)
-	var rt = NewRetryAfter(NewFixedBackoffPolicy(0))(wrapped)
+	var rt = NewRetryAfter()(wrapped)
 
 	rtFunc := func(r *http.Request) (*http.Response, error) {
 		return &http.Response{
@@ -44,7 +44,7 @@ func TestRetryAfter429NoRetryAfter(t *testing.T) {
 	defer ctrl.Finish()
 
 	var wrapped = NewMockRoundTripper(ctrl)
-	var rt = NewRetryAfter(NewExponentialBackoffPolicy(10 * time.Millisecond))(wrapped)
+	var rt = NewRetryAfter()(wrapped)
 
 	var rtFunc429 = func(r *http.Request) (*http.Response, error) {
 		return &http.Response{
@@ -73,8 +73,8 @@ func TestRetryAfter429NoRetryAfter(t *testing.T) {
 	}
 
 	durationInMilliseconds := int64(duration / time.Millisecond)
-	if durationInMilliseconds < 30 {
-		t.Fatalf("expected execution time to take at least 10 + 20 milliseconds due to use of exponential backoff with initial value of 10 and two replies with 429, but got %d", durationInMilliseconds)
+	if durationInMilliseconds < 60 {
+		t.Fatalf("expected execution time to take at least 20 + 40 milliseconds due to use of exponential backoff with initial value of 20 and two replies with 429, but got %d", durationInMilliseconds)
 	}
 }
 
@@ -85,7 +85,7 @@ func TestRetryAfter429ComboNoRetryAfterAndWithRetryAfter(t *testing.T) {
 	defer ctrl.Finish()
 
 	var wrapped = NewMockRoundTripper(ctrl)
-	var rt = NewRetryAfter(NewExponentialBackoffPolicy(20 * time.Millisecond))(wrapped)
+	var rt = NewRetryAfter()(wrapped)
 
 	var rtFunc429NoRetryAfter = func(r *http.Request) (*http.Response, error) {
 		return &http.Response{
@@ -136,7 +136,7 @@ func TestRetryAfter429BadRetryAfter(t *testing.T) {
 	defer ctrl.Finish()
 
 	var wrapped = NewMockRoundTripper(ctrl)
-	var rt = NewRetryAfter(NewFixedBackoffPolicy(0))(wrapped)
+	var rt = NewRetryAfter()(wrapped)
 
 	rtFunc := func(r *http.Request) (*http.Response, error) {
 		return &http.Response{
@@ -167,7 +167,7 @@ func TestRetryAfter429WithRetryAfter(t *testing.T) {
 	defer ctrl.Finish()
 
 	var wrapped = NewMockRoundTripper(ctrl)
-	var rt = NewRetryAfter(NewFixedBackoffPolicy(0))(wrapped)
+	var rt = NewRetryAfter()(wrapped)
 
 	rtFunc1 := func(r *http.Request) (*http.Response, error) {
 		return &http.Response{
@@ -206,7 +206,7 @@ func TestRetryAfter429WithDeadlineExceeded(t *testing.T) {
 	defer ctrl.Finish()
 
 	var wrapped = NewMockRoundTripper(ctrl)
-	var rt = NewRetryAfter(NewFixedBackoffPolicy(0))(wrapped)
+	var rt = NewRetryAfter()(wrapped)
 
 	var ctx, cancel = context.WithTimeout(context.Background(), time.Hour)
 	defer cancel()
@@ -243,7 +243,7 @@ func TestRetryContextCanceled(t *testing.T) {
 	defer ctrl.Finish()
 
 	var wrapped = NewMockRoundTripper(ctrl)
-	var rt = NewRetryAfter(NewFixedBackoffPolicy(0))(wrapped)
+	var rt = NewRetryAfter()(wrapped)
 
 	var ctx, cancel = context.WithTimeout(context.Background(), time.Hour)
 	defer cancel()

--- a/retryafter_test.go
+++ b/retryafter_test.go
@@ -16,7 +16,7 @@ func TestRetryAfterNot429(t *testing.T) {
 	defer ctrl.Finish()
 
 	var wrapped = NewMockRoundTripper(ctrl)
-	var rt = NewRetryAfter()(wrapped)
+	var rt = NewRetryAfter(NewFixedBackoffPolicy(0))(wrapped)
 
 	rtFunc := func(r *http.Request) (*http.Response, error) {
 		return &http.Response{
@@ -44,24 +44,88 @@ func TestRetryAfter429NoRetryAfter(t *testing.T) {
 	defer ctrl.Finish()
 
 	var wrapped = NewMockRoundTripper(ctrl)
-	var rt = NewRetryAfter()(wrapped)
+	var rt = NewRetryAfter(NewExponentialBackoffPolicy(10 * time.Millisecond))(wrapped)
 
-	rtFunc := func(r *http.Request) (*http.Response, error) {
+	var rtFunc429 = func(r *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: 429,
 			Body:       http.NoBody,
 		}, nil
 	}
-
-	wrapped.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(rtFunc).Times(1)
+	var rtFunc200 = func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       http.NoBody,
+		}, nil
+	}
+	wrapped.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(rtFunc429).Times(2)
+	wrapped.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(rtFunc200).Times(1)
 
 	var req, _ = http.NewRequest(http.MethodGet, "/", nil)
+	start := time.Now()
 	var resp, e = rt.RoundTrip(req)
+	duration := time.Since(start)
 	if e != nil {
 		t.Fatal(e.Error())
 	}
-	if resp.StatusCode != 429 {
-		t.Fatalf("expected 429 but got %d", resp.StatusCode)
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200 but got %d", resp.StatusCode)
+	}
+
+	durationInMilliseconds := int64(duration / time.Millisecond)
+	if durationInMilliseconds < 30 {
+		t.Fatalf("expected execution time to take at least 10 + 20 milliseconds due to use of exponential backoff with initial value of 10 and two replies with 429, but got %d", durationInMilliseconds)
+	}
+}
+
+func TestRetryAfter429ComboNoRetryAfterAndWithRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	var ctrl = gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var wrapped = NewMockRoundTripper(ctrl)
+	var rt = NewRetryAfter(NewExponentialBackoffPolicy(20 * time.Millisecond))(wrapped)
+
+	var rtFunc429NoRetryAfter = func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 429,
+			Body:       http.NoBody,
+		}, nil
+	}
+	var rtFunc429WithRetryAfter = func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 429,
+			Body:       http.NoBody,
+			Header: map[string][]string{
+				"Retry-After": []string{"10"},
+			},
+		}, nil
+	}
+	var rtFunc200 = func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       http.NoBody,
+		}, nil
+	}
+	wrapped.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(rtFunc429NoRetryAfter).Times(1)
+	wrapped.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(rtFunc429WithRetryAfter).Times(1)
+	wrapped.EXPECT().RoundTrip(gomock.Any()).DoAndReturn(rtFunc200).Times(1)
+
+	var req, _ = http.NewRequest(http.MethodGet, "/", nil)
+	start := time.Now()
+	var resp, e = rt.RoundTrip(req)
+	duration := time.Since(start)
+	if e != nil {
+		t.Fatal(e.Error())
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200 but got %d", resp.StatusCode)
+	}
+
+	durationInMilliseconds := int64(duration / time.Millisecond)
+	if durationInMilliseconds < 30 {
+		t.Fatalf("expected execution time to take at least 20 + 10 milliseconds due to use of exponential backoff with initial value of 20 and two replies with 429 where the second reply has Retry-After=10 header, but got %d", durationInMilliseconds)
 	}
 }
 
@@ -72,7 +136,7 @@ func TestRetryAfter429BadRetryAfter(t *testing.T) {
 	defer ctrl.Finish()
 
 	var wrapped = NewMockRoundTripper(ctrl)
-	var rt = NewRetryAfter()(wrapped)
+	var rt = NewRetryAfter(NewFixedBackoffPolicy(0))(wrapped)
 
 	rtFunc := func(r *http.Request) (*http.Response, error) {
 		return &http.Response{
@@ -103,7 +167,7 @@ func TestRetryAfter429WithRetryAfter(t *testing.T) {
 	defer ctrl.Finish()
 
 	var wrapped = NewMockRoundTripper(ctrl)
-	var rt = NewRetryAfter()(wrapped)
+	var rt = NewRetryAfter(NewFixedBackoffPolicy(0))(wrapped)
 
 	rtFunc1 := func(r *http.Request) (*http.Response, error) {
 		return &http.Response{
@@ -142,7 +206,7 @@ func TestRetryAfter429WithDeadlineExceeded(t *testing.T) {
 	defer ctrl.Finish()
 
 	var wrapped = NewMockRoundTripper(ctrl)
-	var rt = NewRetryAfter()(wrapped)
+	var rt = NewRetryAfter(NewFixedBackoffPolicy(0))(wrapped)
 
 	var ctx, cancel = context.WithTimeout(context.Background(), time.Hour)
 	defer cancel()
@@ -179,7 +243,7 @@ func TestRetryContextCanceled(t *testing.T) {
 	defer ctrl.Finish()
 
 	var wrapped = NewMockRoundTripper(ctrl)
-	var rt = NewRetryAfter()(wrapped)
+	var rt = NewRetryAfter(NewFixedBackoffPolicy(0))(wrapped)
 
 	var ctx, cancel = context.WithTimeout(context.Background(), time.Hour)
 	defer cancel()


### PR DESCRIPTION
…licy for cases where servers return 429 without a Retry-After header

Also added an ExponentialBackoffer since that is often the recommendation from APIs that give back 429 without a Retry-After header directive.