### PR TITLE
http spec says Retry-After header is seconds, not milliseconds

### DIFF
--- a/retryafter.go
+++ b/retryafter.go
@@ -54,7 +54,7 @@ func (c *RetryAfter) RoundTrip(r *http.Request) (*http.Response, error) {
 				if retryAfterInt, err = strconv.Atoi(retryAfterString); err != nil {
 					break
 				}
-				retryAfter = time.Duration(retryAfterInt) * time.Millisecond
+				retryAfter = time.Duration(retryAfterInt) * time.Second
 			}
 		}
 	}
@@ -68,6 +68,6 @@ func (c *RetryAfter) RoundTrip(r *http.Request) (*http.Response, error) {
 // using the Retry-After header directive when present, or the backoffPolicy if not present.
 func NewRetryAfter() func(http.RoundTripper) http.RoundTripper {
 	return func(wrapped http.RoundTripper) http.RoundTripper {
-		return &RetryAfter{wrapped: wrapped, backoffPolicy: NewExponentialBackoffPolicy(20 * time.Millisecond)}
+		return &RetryAfter{wrapped: wrapped, backoffPolicy: NewExponentialBackoffPolicy(1 * time.Second)}
 	}
 }

--- a/retryafter_test.go
+++ b/retryafter_test.go
@@ -72,9 +72,9 @@ func TestRetryAfter429NoRetryAfter(t *testing.T) {
 		t.Fatalf("expected 200 but got %d", resp.StatusCode)
 	}
 
-	durationInMilliseconds := int64(duration / time.Millisecond)
-	if durationInMilliseconds < 60 {
-		t.Fatalf("expected execution time to take at least 20 + 40 milliseconds due to use of exponential backoff with initial value of 20 and two replies with 429, but got %d", durationInMilliseconds)
+	durationInSeconds := int64(duration / time.Second)
+	if durationInSeconds < 3 {
+		t.Fatalf("expected execution time to take at least 1 + 2 seconds due to use of exponential backoff with initial value of 1 and two replies with 429, but got %d", durationInSeconds)
 	}
 }
 
@@ -98,7 +98,7 @@ func TestRetryAfter429ComboNoRetryAfterAndWithRetryAfter(t *testing.T) {
 			StatusCode: 429,
 			Body:       http.NoBody,
 			Header: map[string][]string{
-				"Retry-After": []string{"10"},
+				"Retry-After": []string{"1"},
 			},
 		}, nil
 	}
@@ -123,9 +123,9 @@ func TestRetryAfter429ComboNoRetryAfterAndWithRetryAfter(t *testing.T) {
 		t.Fatalf("expected 200 but got %d", resp.StatusCode)
 	}
 
-	durationInMilliseconds := int64(duration / time.Millisecond)
-	if durationInMilliseconds < 30 {
-		t.Fatalf("expected execution time to take at least 20 + 10 milliseconds due to use of exponential backoff with initial value of 20 and two replies with 429 where the second reply has Retry-After=10 header, but got %d", durationInMilliseconds)
+	durationInSeconds := int64(duration / time.Second)
+	if durationInSeconds < 2 {
+		t.Fatalf("expected execution time to take at least 1 + 1 seconds due to use of exponential backoff with initial value of 1 and two replies with 429 where the second reply has Retry-After=1 header, but got %d", durationInSeconds)
 	}
 }
 
@@ -174,7 +174,7 @@ func TestRetryAfter429WithRetryAfter(t *testing.T) {
 			StatusCode: 429,
 			Body:       http.NoBody,
 			Header: map[string][]string{
-				"Retry-After": []string{"10"},
+				"Retry-After": []string{"1"},
 			},
 		}, nil
 	}
@@ -216,7 +216,7 @@ func TestRetryAfter429WithDeadlineExceeded(t *testing.T) {
 			StatusCode: 429,
 			Body:       http.NoBody,
 			Header: map[string][]string{
-				"Retry-After": []string{"10"},
+				"Retry-After": []string{"1"},
 			},
 		}, nil
 	}


### PR DESCRIPTION
The spec says Retry-After is seconds.  This PR fixes the mistreatment of the header.

Re: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After