### PR TITLE
Use deep copy when cloning requests

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -26,12 +26,15 @@ func newRequestCopier(r *http.Request) (*requestCopier, error) {
 	if r.Body != nil {
 		body, e = ioutil.ReadAll(r.Body)
 	}
+	// Setting the request body to nil after capturing it so that it is not
+	// included in the deep copy. This code already manages copying the
+	// content body.
+	r.Body = nil
 	return &requestCopier{original: r, body: body}, e
 }
 
 func (r *requestCopier) Copy() *http.Request {
-	var newRequest = new(http.Request)
-	*newRequest = *r.original
+	var newRequest = r.original.Clone(r.original.Context())
 	newRequest.Body = nil
 	if r.body != nil {
 		newRequest.Body = ioutil.NopCloser(bytes.NewBuffer(r.body))


### PR DESCRIPTION
The previous version of this code uses a shallow copy of the request
object when retrying or hedging. So long as shared attributes of the
request, such as the headers map, is read-only during the retry/hedge
then there is no issue. However, if the retry or hedger is wrapped
around subsequent middleware that modifies a shared asset, such as
injecting a header value, then it creates a race condition and panics.

I've added a test case that reliably triggers the race detector during
tests and switched the shallow copy to a deep copy of the request.